### PR TITLE
display performance logs to stdout when running model generators

### DIFF
--- a/tools/generate_taint_models/__init__.py
+++ b/tools/generate_taint_models/__init__.py
@@ -111,11 +111,16 @@ def run_generators(
 
         generated_models[mode] = set(generator_options[mode].generate_models())
 
+        elapsed_time_seconds = time.time() - start
+        LOG.info(
+            f"Computed models for `{mode}` in {elapsed_time_seconds:.3f} seconds."
+        )
+
         if logger_executable is not None:
-            elapsed_time = int((time.time() - start) * 1000)
+            elapsed_time_milliseconds = int(elapsed_time_seconds * 1000)
             log_statistics(
                 "perfpipe_pyre_performance",
-                integers={"time": elapsed_time},
+                integers={"time": elapsed_time_milliseconds},
                 normals={"name": "model generation", "model kind": mode},
                 logger=logger_executable,
             )


### PR DESCRIPTION
Summary: We're already logging these to scuba, but it's nice to have it human-available as well.

Reviewed By: grievejia

Differential Revision: D19908458

fbshipit-source-id: e7a8abe544dc3bed66c58714f2a016f79d14002a